### PR TITLE
test demonstrating err.incomplete api is broken, creating corruption in Streams (and future iterators)

### DIFF
--- a/tests/test-incomplete.js
+++ b/tests/test-incomplete.js
@@ -1,0 +1,37 @@
+import { encode } from '../index.js'
+import { assert } from 'chai'
+import { Decoder } from '../decode.js'
+
+const tests = {
+  string: 'interesting string',
+  number: 12345,
+  buffer: Buffer.from('hello world'),
+  bigint: 12345678910n,
+  array: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  set: new Set('abcdefghijklmnopqrstuvwxyz'.split('')),
+  object: { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 }
+}
+
+suite('encode and decode tests with partial values', function () {
+  const decoder = new Decoder({ objectMode: true, structures: [] })
+
+  for (const [label, testData] of Object.entries(tests)) {
+    test(label, () => {
+      const encoded = encode(testData)
+      assert.isTrue(Buffer.isBuffer(encoded), 'encode returns a Buffer')
+      assert.deepStrictEqual(decoder.decode(encoded, encoded.length, true), testData, 'full buffer decodes well')
+      const firstHalf = encoded.slice(0, Math.floor(encoded.length / 2))
+      let value
+      try {
+        value = decoder.decode(firstHalf, firstHalf.length, true)
+      } catch (err) {
+        if (err.incomplete !== true) {
+          assert.fail(`Should throw an error with .incomplete set to true, instead threw error <${err}>`)
+        } else {
+          return; // victory! correct outcome!
+        }
+      }
+      assert.fail(`Should throw an error with .incomplete set to true, instead returned value ${JSON.stringify(value)}`)
+    })
+  }
+})


### PR DESCRIPTION
`stream.js` provides a decoder stream implementation which depends on Decoder throwing Error's which have an 'incomplete' property set to true, when the Decoder is given a buffer which contains the start of a valid CBOR entity, but which is not long enough to complete the value. For example, a buffer, string, multi-byte integer, array, object, or Set, which includes a length value.

cbor-x currently fails in a variety of ways, demonstrated by this minimal set of tests. We should probably have more extensive tests over all the types which can be represented using multiple bytes or can have a variable length. It would be good to see, for example, explicit maps, tags, floats. Perhaps ideally we could find a set of test data for every core cbor type that cbor-x is supposed to support, in every form the spec specifies (both explicit length and indeterminate arrays with terminators for example) and build a very extensive test which crops those test buffers to every possible length between 0 length buffer and the full length of the encoded sample data, validating that cbor-x always throws err.incomplete or returns a deepStrictEqual matching value at every length.

But, for now, this does show the problem. It cannot be worked around fully by having streams and iterators always preserve the incomplete buffer whenever *any* error is thrown, because sometimes cbor-x decoder will instead respond with a value of the correct type, but which contains incorrect data. Note the output of incomplete strings, buffers, arrays, objects, and sets, which return a seemingly valid value, but the data contained is incorrect, often containing zeros where other information should be.

Did I miss anything?

```
npx mocha tests/test-incomplete.js -u tdd --experimental-json-modules


  encode and decode tests with partial values
    1) string
    2) number
    3) buffer
    4) bigint
    5) array
    6) set
    7) object


  0 passing (8ms)
  7 failing

  1) encode and decode tests with partial values
       string:
     AssertionError: Should throw an error with .incomplete set to true, instead returned value "interest\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000"
      at Context.<anonymous> (file:///Users/phx/GitHub/cbor-x/tests/test-incomplete.js:34:14)
      at processImmediate (node:internal/timers:464:21)

  2) encode and decode tests with partial values
       number:
     AssertionError: Should throw an error with .incomplete set to true, instead threw error <RangeError: Offset is outside the bounds of the DataView>
      at Context.<anonymous> (file:///Users/phx/GitHub/cbor-x/tests/test-incomplete.js:29:18)
      at processImmediate (node:internal/timers:464:21)

  3) encode and decode tests with partial values
       buffer:
     AssertionError: Should throw an error with .incomplete set to true, instead returned value {"type":"Buffer","data":[104,101,108,108,111]}
      at Context.<anonymous> (file:///Users/phx/GitHub/cbor-x/tests/test-incomplete.js:34:14)
      at processImmediate (node:internal/timers:464:21)

  4) encode and decode tests with partial values
       bigint:
     AssertionError: Should throw an error with .incomplete set to true, instead threw error <RangeError: Offset is outside the bounds of the DataView>
      at Context.<anonymous> (file:///Users/phx/GitHub/cbor-x/tests/test-incomplete.js:29:18)
      at processImmediate (node:internal/timers:464:21)

  5) encode and decode tests with partial values
       array:
     AssertionError: Should throw an error with .incomplete set to true, instead returned value [1,2,3,4,0,0,0,0,0,0]
      at Context.<anonymous> (file:///Users/phx/GitHub/cbor-x/tests/test-incomplete.js:34:14)
      at processImmediate (node:internal/timers:464:21)

  6) encode and decode tests with partial values
       set:
     AssertionError: Should throw an error with .incomplete set to true, instead returned value {}
      at Context.<anonymous> (file:///Users/phx/GitHub/cbor-x/tests/test-incomplete.js:34:14)
      at processImmediate (node:internal/timers:464:21)

  7) encode and decode tests with partial values
       object:
     AssertionError: full buffer decodes well: expected {} to deeply equal { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 }
      at Context.<anonymous> (file:///Users/phx/GitHub/cbor-x/tests/test-incomplete.js:22:14)
      at processImmediate (node:internal/timers:464:21)
```