### PR TITLE
encodeIter and decodeIter implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 export { Encoder, addExtension, encode, NEVER, ALWAYS, DECIMAL_ROUND, DECIMAL_FIT } from './encode.js'
 export { Tag, Decoder, decodeMultiple, decode, FLOAT32_OPTIONS, clearSource } from './decode.js'
+export { decodeIter, encodeIter } from './iterators.js'
 export const useRecords = false
 export const mapsAsObjects = true

--- a/iterators.js
+++ b/iterators.js
@@ -1,0 +1,85 @@
+import { Encoder } from './encode.js'
+import { Decoder } from './decode.js'
+
+/**
+ * Given an Iterable first argument, returns an Iterable where each value is encoded as a Buffer
+ * If the argument is only Async Iterable, the return value will be an Async Iterable.
+ * @param {Iterable|Iterator|AsyncIterable|AsyncIterator} objectIterator - iterable source, like a Readable object stream, an array, Set, or custom object
+ * @param {options} [options] - cbor-x Encoder options
+ * @returns {IterableIterator|Promise.<AsyncIterableIterator>}
+ */
+export function encodeIter (objectIterator, options = {}) {
+  if (!objectIterator || typeof objectIterator !== 'object') {
+    throw new Error('first argument must be an Iterable, Async Iterable, or a Promise for an Async Iterable')
+  } else if (typeof objectIterator[Symbol.iterator] === 'function') {
+    return encodeIterSync(objectIterator, options)
+  } else if (typeof objectIterator.then === 'function' || typeof objectIterator[Symbol.asyncIterator] === 'function') {
+    return encodeIterAsync(objectIterator, options)
+  } else {
+    throw new Error('first argument must be an Iterable, Async Iterable, Iterator, Async Iterator, or a Promise')
+  }
+}
+
+function * encodeIterSync (objectIterator, options) {
+  const encoder = new Encoder(options)
+  for (const value of objectIterator) {
+    yield encoder.encode(value)
+  }
+}
+
+async function * encodeIterAsync (objectIterator, options) {
+  const encoder = new Encoder(options)
+  for await (const value of objectIterator) {
+    yield encoder.encode(value)
+  }
+}
+
+/**
+ * Given an Iterable/Iterator input which yields buffers, returns an IterableIterator which yields sync decoded objects
+ * Or, given an Async Iterable/Iterator which yields promises resolving in buffers, returns an AsyncIterableIterator.
+ * @param {Iterable|Iterator|AsyncIterable|AsyncIterableIterator} bufferIterator
+ * @param {object} [options] - Decoder options
+ * @returns {IterableIterator|Promise.<AsyncIterableIterator}
+ */
+export function decodeIter (bufferIterator, options = {}) {
+  if (!bufferIterator || typeof bufferIterator !== 'object') {
+    throw new Error('first argument must be an Iterable, Async Iterable, Iterator, Async Iterator, or a promise')
+  }
+
+  const decoder = new Decoder(options)
+  let incomplete
+  const parser = (chunk) => {
+    let yields
+    // if there's incomplete data from previous chunk, concatinate and try again
+    if (incomplete) {
+      chunk = Buffer.concat([incomplete, chunk])
+      incomplete = undefined
+    }
+
+    try {
+      yields = decoder.decodeMultiple(chunk)
+    } catch (err) {
+      if (err.incomplete) {
+        incomplete = chunk.slice(err.lastPosition)
+        yields = err.values
+      } else {
+        throw err
+      }
+    }
+    return yields
+  }
+
+  if (typeof bufferIterator[Symbol.iterator] === 'function') {
+    return (function * iter () {
+      for (const value of bufferIterator) {
+        yield * parser(value)
+      }
+    })()
+  } else if (typeof bufferIterator[Symbol.asyncIterator] === 'function') {
+    return (async function * iter () {
+      for await (const value of bufferIterator) {
+        yield * parser(value)
+      }
+    })()
+  }
+}

--- a/node-index.js
+++ b/node-index.js
@@ -1,6 +1,7 @@
 export { Encoder, addExtension, encode, NEVER, ALWAYS, DECIMAL_ROUND, DECIMAL_FIT } from './encode.js'
 export { Tag, Decoder, decodeMultiple, decode, FLOAT32_OPTIONS } from './decode.js'
 export { EncoderStream, DecoderStream } from './stream.js'
+export { decodeIter, encodeIter } from './iterators.js'
 export const useRecords = false
 export const mapsAsObjects = true
 import { setExtractor } from './decode.js'

--- a/tests/test-node-iterators.js
+++ b/tests/test-node-iterators.js
@@ -1,0 +1,72 @@
+import { encodeIter, decodeIter } from '../index.js'
+import { decode } from '../index.js'
+import { assert } from 'chai'
+
+const tests = [
+  null,
+  false,
+  true,
+  'interesting string',
+  12345,
+  123456789n,
+  123.456,
+  Buffer.from('Hello World'),
+  new Set('abcdefghijklmnopqrstuvwxyz'.split(''))
+]
+
+suite('cbor-x iterators interface tests', function () {
+  test('sync encode iterator', () => {
+    const encodings = [...encodeIter(tests)]
+    const decodings = encodings.map(x => decode(x))
+    assert.deepStrictEqual(decodings, tests)
+  })
+
+  test('async encode iterator', async () => {
+    async function * generate () {
+      for (const test of tests) {
+        await new Promise((resolve, reject) => setImmediate(resolve))
+        yield test
+      }
+    }
+
+    const chunks = []
+    for await (const chunk of encodeIter(generate())) {
+      chunks.push(chunk)
+    }
+
+    const decodings = chunks.map(x => decode(x))
+    assert.deepStrictEqual(decodings, tests)
+  })
+
+  test('sync encode and decode iterator', () => {
+    const encodings = [...encodeIter(tests)]
+    assert.isTrue(encodings.every(v => Buffer.isBuffer(v)))
+    const decodings = [...decodeIter(encodings)]
+    assert.deepStrictEqual(decodings, tests)
+
+    // also test decodings work with buffers multiple values in a buffer
+    const concatEncoding = Buffer.concat([...encodings])
+    const decodings2 = [...decodeIter([concatEncoding])]
+    assert.deepStrictEqual(decodings2, tests)
+
+    // also test decodings work with partial buffers that don't align to values perfectly
+    const half1 = concatEncoding.slice(0, Math.floor(concatEncoding.length / 2))
+    const half2 = concatEncoding.slice(Math.floor(concatEncoding.length / 2))
+    const decodings3 = [...decodeIter([half1, half2])]
+    assert.deepStrictEqual(decodings3, tests)
+  })
+
+  test('async encode and decode iterator', async () => {
+    async function * generator () {
+      for (const obj of tests) {
+        await new Promise((resolve, reject) => setImmediate(resolve))
+        yield obj
+      }
+    }
+    const yields = []
+    for await (const value of decodeIter(encodeIter(generator()))) {
+      yields.push(value)
+    }
+    assert.deepStrictEqual(yields, tests)
+  })
+})


### PR DESCRIPTION
For your consideration, an iterable implementation of streaming encoder/decoder. This avoids issues with root level null values, and it's just a little nicer to work with in some situations. For example:

```js
for await (const value of cbor.decodeIter(fs.createReadStream('dataset.cbor'))) {
  // do something with each value
}
```

feels nicer than trying to wrangle a pipeline, or debug missing errors using equivilent pipe syntax, and natively handles null values well, and it looks likely browser whatwg streams will work as iterables like modern node streams do, so it has a nice equivilence in the browser world, allowing people to use the same or very similar code in both places without needing to bundle a node-like streams implementation for browsers, though it does still use node Buffer's currently.