### PR TITLE
fix termination of parsing after first decoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ let encoder = new Encoder({
 Cbor-x will automatically add and saves structures as it encounters any new object structures (up to a limit of 64). It will always add structures in incremental/compatible way: Any object encoded with an earlier structure can be decoded with a later version (as long as it is persisted).
 
 ### Reading Multiple Values
-If you have a buffer with multiple values sequentially encoded, you can choose to parse and read multiple values. This can be done using the `unpackMultiple` function/method, which can return an array of all the values it can sequentially parse within the provided buffer. For example:
+If you have a buffer with multiple values sequentially encoded, you can choose to parse and read multiple values. This can be done using the `decodeMultiple` function/method, which can return an array of all the values it can sequentially parse within the provided buffer. For example:
 ```js
 let data = new Uint8Array([1, 2, 3]) // encodings of values 1, 2, and 3
 let values = decodeMultiple(data) // [1, 2, 3]

--- a/decode.js
+++ b/decode.js
@@ -86,7 +86,9 @@ export class Decoder {
 			sequentialMode = true
 			let value = this ? this.decode(source, size) : defaultDecoder.decode(source, size)
 			if (forEach) {
-				forEach(value)
+				if (forEach(value) === false) {
+					return
+				}
 				while(position < size) {
 					lastPosition = position
 					if (forEach(checkedRead()) === false) {


### PR DESCRIPTION
```
let data = new Uint8Array([1, 2, 3]) // encodings of values 1, 2, and 3
decodeMultiple(data, (value) => {
	console.log(value)
	return false
})
```
results in
```
1
2
```
when it should be
```
1
```