### PR TITLE
remove unnecessary import

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -1,4 +1,3 @@
-import { write } from 'fs'
 import { Decoder, mult10, Tag, typedArrays, addExtension as decodeAddExtension } from './decode.js'
 let textEncoder
 try {


### PR DESCRIPTION
fixes
```
 > node_modules/.pnpm/cbor-x@0.9.1/node_modules/cbor-x/encode.js:1:9: error: No matching export in "browser-external:fs" for import "write"
    1 │ import { write } from 'fs'
```
on web