### PR TITLE
Add `package.json` to exports to support previously exported values

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
       "default": {
         "import": "./decode.js"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "/dist",


### PR DESCRIPTION
Adds `package.json` to list of `exports` to make it accessible and imports more backward compatible with pre ESM days.

[See NodeJS docs on the subject](https://nodejs.org/docs/latest-v16.x/api/packages.html#package-entry-points).

Feel free to close this if this is something you do not want of course!