### PR TITLE
Fix types for `Extension`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,11 +27,12 @@ export interface Options {
 	onInvalidDate?: () => any
 	tagUint8Array?: boolean
 }
-interface Extension {
-	Class: Function
+type ClassOf<T> = new (...args: any[]) => T;
+interface Extension<T, R> {
+	Class: ClassOf<T>
 	tag: number
-	encode(value: any): Buffer | Uint8Array
-	decode(messagePack: Buffer | Uint8Array): any
+	encode(value: T, encodeFn: (data: R) => Uint8Array): Buffer | Uint8Array
+	decode(item: R): T
 }
 export class Decoder {
 	constructor(options?: Options)
@@ -40,7 +41,7 @@ export class Decoder {
 }
 export function decode(messagePack: Buffer | Uint8Array): any
 export function decodeMultiple(messagePack: Buffer | Uint8Array, forEach?: (value: any) => any): [] | void
-export function addExtension(extension: Extension): void
+export function addExtension<T, R>(extension: Extension<T, R>): void
 export function clearSource(): void
 export function roundFloat32(float32Number: number): number
 export let isNativeAccelerationEnabled: boolean


### PR DESCRIPTION
These types don't match the implementation and also don't enforce much safety. These new types both match the implementation as well as are much safer. Now one can write code like:

```
class Foo {
  bar: number;
  constructor(bar: number) {
    this.bar = bar;
  }
}

addExtension({
  Class: Foo,
  tag: 0,
  encode(value, encode: (item: number) => Uint8Array) {
    return encode(value.bar);
  },
  decode(bar) {
    return new Foo(bar);
  }
})
```

1. The first parameter of encode will be properly inferred as a `Foo`,
2. The first parameter of decode will be properly inferred as a `number`
3. Decode will need to return a instance of `Foo`

[Playground link here](https://www.typescriptlang.org/play?ssl=27&ssc=3&pln=11&pc=1#code/C4TwDgpgBAwgNgQwM5IPIDMA8AVAfFAXigDsIB3KACgDpaEAnAcyQC4oFiQBtAXQEpC+bAG4AUAEtiwCPXQIAxtACiAD2nEk4gPbEcAGigAlfAG9RASHjJWsRCgw5cF4AkZtiAVwC2AIxkWIYnktABMISgA3BDgPCDZsA0DgsIAxYjZKEIQXNkMBAnwAVUlgAA4AQXp6BBA+NmKpCqqaizDk8PFpL1y6qGxRAF9RUTbEemh0DyDgbWJ2EJDVdU0dfSNcSgg1QJX0qCWd2bXjXoitcRDh+TskKBStLSgzKCgfBndvP3oxF+CNYHoHnkwC09Eob3oH18MgEzxeUGAAAtxEhqBDCK8GD8oEMhqIEAsDhpZpQ4VYUGx7lo9KIXi43FAAAw0l5JULhKIxCCJILsjKdCDdEifGGCKANMqVaq1J60+HjYAeehzNlhSLRWJohh8bEDFlQNrs8Ha2XwqAKpVzUgUKnG+g6uW4vhAA)