### PR TITLE
(chore) update mocha version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "chai": "^4.3.4",
     "cpy-cli": "^4.1.0",
     "esm": "^3.2.25",
-    "mocha": "^8.1.3",
+    "mocha": "^10.1.0",
     "rollup": "^1.20.3",
     "rollup-plugin-babel-minify": "^9.0.0"
   }


### PR DESCRIPTION
Eeliminates npm audit vulnerability warning messages:

```
# npm audit report

minimatch  <3.0.5
Severity: high
minimatch ReDoS vulnerability - https://github.com/advisories/GHSA-f8q6-p94x-37v3
fix available via `npm audit fix`
node_modules/minimatch
  mocha  5.1.0 - 9.2.1
  Depends on vulnerable versions of minimatch
  Depends on vulnerable versions of nanoid
  node_modules/mocha

nanoid  3.0.0 - 3.1.30
Severity: moderate
Exposure of Sensitive Information to an Unauthorized Actor in nanoid - https://github.com/advisories/GHSA-qrpm-p2h7-hrv2
fix available via `npm audit fix`
node_modules/nanoid

3 vulnerabilities (1 moderate, 2 high)
```