### PR TITLE
ignore buffer in browsers

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -4,6 +4,7 @@ try {
 	textEncoder = new TextEncoder()
 } catch (error) {}
 let extensions, extensionClasses
+const Buffer = globalThis.Buffer
 const hasNodeBuffer = typeof Buffer !== 'undefined'
 const ByteArrayAllocate = hasNodeBuffer ? Buffer.allocUnsafeSlow : Uint8Array
 const ByteArray = hasNodeBuffer ? Buffer : Uint8Array

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "/*.js",
     "/*.ts"
   ],
+  "browser": {
+    "node:buffer": false
+  },
   "optionalDependencies": {
     "cbor-extract": "^2.1.1"
   },


### PR DESCRIPTION
Buffer is optional, adding this will prevent eg: jsdeliver to automatically adding it for just using the `Buffer` keyword

https://cdn.jsdelivr.net/npm/cbor-x@1.5.0/browser.js/+esm