### PR TITLE
Fix TypedArray decode when data is aligned

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -1095,7 +1095,7 @@ function registerTypedArray(TypedArray, tag) {
 	for (let littleEndian = 0; littleEndian < 2; littleEndian++) {
 		if (!littleEndian && bytesPerElement == 1)
 			continue
-		let sizeShift = bytesPerElement == 2 ? 1 : bytesPerElement == 4 ? 2 : 3
+		let sizeShift = bytesPerElement == 2 ? 1 : bytesPerElement == 4 ? 2 : bytesPerElement == 8 ? 3 : 0
 		currentExtensions[littleEndian ? tag : (tag - 4)] = (bytesPerElement == 1 || littleEndian == isLittleEndianMachine) ? (buffer) => {
 			if (!TypedArray)
 				throw new Error('Could not find typed array for code ' + tag)
@@ -1105,7 +1105,7 @@ function registerTypedArray(TypedArray, tag) {
 					bytesPerElement === 2 && !(buffer.byteOffset & 1) ||
 					bytesPerElement === 4 && !(buffer.byteOffset & 3) ||
 					bytesPerElement === 8 && !(buffer.byteOffset & 7))
-					return new TypedArray(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+					return new TypedArray(buffer.buffer, buffer.byteOffset, buffer.byteLength >> sizeShift);
 			}
 			// we have to slice/copy here to get a new ArrayBuffer, if we are not word/byte aligned
 			return new TypedArray(Uint8Array.prototype.slice.call(buffer, 0).buffer)

--- a/tests/test.js
+++ b/tests/test.js
@@ -811,6 +811,15 @@ suite('CBOR basic tests', function(){
 		let deserialized = decode(Buffer.concat(result));
 		console.log(performance.now() - start, result.length);
 	});
+
+	test('little-endian typed array with aligned data', function() {
+	    // array[1] { uint32-little-endian-typed-array { bytes <00 00 00 00> } }
+	    let data = new Uint8Array([ 129, 216, 70, 68, 0, 0, 0, 0 ]);
+	    assert.deepEqual(decode(data), [new Uint32Array([0])]);
+
+	    let value = {x: new Float32Array([1, 2, 3])};
+	    assert.deepEqual(decode(encode(value)), value);
+	});
 })
 suite('CBOR performance tests', function(){
 	test('performance JSON.parse', function() {


### PR DESCRIPTION
The typed array constructor signature is `TypedArray(buffer, byteOffset, length)`, where length is the element count, so the fast path (the bit with the "try to provide a direct view" comment) was either making the wrong sized arrays or failing due to insufficient source data.