### PR TITLE
Fix sometimes stream decode throw `Invalid property name type`

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -507,7 +507,9 @@ function safeKey(key) {
 	if (typeof key === 'number' || typeof key === 'boolean' || typeof key === 'bigint') return key.toString();
 	if (key == null) return key + '';
 	// protect against expensive (DoS) string conversions
-	throw new Error('Invalid property name type ' + typeof key);
+	let error = new Error('Invalid property name type ' + typeof key);
+	if (typeof key === 'object') error.incomplete = true;
+	throw error;
 }
 
 let readFixedString = readStringJS


### PR DESCRIPTION
My enc/dec options:

```js
{
  keyMap: {...},
  useRecords: false,
  pack: true,
}
```

I'm cannot provide the actual payload.