### PR TITLE
Support re-encoding of indefinite length types.

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -447,6 +447,18 @@ export class Encoder extends Decoder {
 					position += 8
 				}
 			} else if (type === 'object') {
+				if( value instanceof String){
+					if (value._cbor_indef && this.preserveIndefiniteLength){
+						target[position++]= 0x7f
+						value._cbor_indef.forEach(str=>{
+							encode(str)
+						})
+						target[position++]=0xff
+					}else{
+						encode(String(value))
+					}
+					return
+				}
 				if (!value)
 					target[position++] = 0xf6
 				else {
@@ -471,16 +483,26 @@ export class Encoder extends Decoder {
 					if (constructor === Object) {
 						writeObject(value)
 					} else if (constructor === Array) {
+						const write=()=>{
+							for (let i = 0; i < length; i++) {
+								encode(value[i])
+							}
+						}
 						length = value.length
+						if (value._cbor_indef && this.preserveIndefiniteLength){
+							target[position++]=0x9f
+							write()
+							target[position++]= 0xff
+							return
+						}
 						if (length < 0x18) {
 							target[position++] = 0x80 | length
 						} else {
 							writeArrayHeader(length)
 						}
-						for (let i = 0; i < length; i++) {
-							encode(value[i])
-						}
+						write()
 					} else if (constructor === Map) {
+
 						if (this.mapsAsObjects ? this.useTag259ForMaps !== false : this.useTag259ForMaps) {
 							// use Tag 259 (https://github.com/shanewholloway/js-cbor-codec/blob/master/docs/CBOR-259-spec--explicit-maps.md) for maps if the user wants it that way
 							target[position++] = 0xd9
@@ -488,7 +510,11 @@ export class Encoder extends Decoder {
 							target[position++] = 3
 						}
 						length = value.size
-						if (length < 0x18) {
+
+						if(encoder.preserveIndefiniteLength &&  value._cbor_indef){
+							target[position++]=0xbf
+						}
+						else if (length < 0x18) {
 							target[position++] = 0xa0 | length
 						} else if (length < 0x100) {
 							target[position++] = 0xb8
@@ -513,6 +539,10 @@ export class Encoder extends Decoder {
 								encode(entryValue)
 							} 	
 						}
+						if(encoder.preserveIndefiniteLength &&  value._cbor_indef){
+							target[position++]=0xff
+						}
+
 					} else {
 						for (let i = 0, l = extensions.length; i < l; i++) {
 							let extensionClass = extensionClasses[i]
@@ -988,8 +1018,8 @@ function isBlob(object) {
 	return tag === 'Blob' || tag === 'File';
 }
 function findRepetitiveStrings(value, packedValues) {
-	switch(typeof value) {
-		case 'string':
+	const valType = typeof value
+	if (valType == 'string' || value instanceof String){
 			if (value.length > 3) {
 				if (packedValues.objectMap[value] > -1 || packedValues.values.length >= packedValues.maxValues)
 					return
@@ -1013,9 +1043,8 @@ function findRepetitiveStrings(value, packedValues) {
 					}
 				}
 			}
-			break
-		case 'object':
-			if (value) {
+		}
+		else if (valType === 'object'){
 				if (value instanceof Array) {
 					for (let i = 0, l = value.length; i < l; i++) {
 						findRepetitiveStrings(value[i], packedValues)
@@ -1031,10 +1060,9 @@ function findRepetitiveStrings(value, packedValues) {
 						}
 					}
 				}
-			}
-			break
-		case 'function': console.log(value)
-	}
+		}
+		else if(valType ==='function') 
+			console.log(value)
 }
 const isLittleEndianMachine = new Uint8Array(new Uint16Array([1]).buffer)[0] == 1
 extensionClasses = [ Date, Set, Error, RegExp, Tag, ArrayBuffer,
@@ -1095,7 +1123,7 @@ extensions = [{ // Date
 		} // else no tag
 	},
 	encode(typedArray, encode, makeRoom) {
-		writeBuffer(typedArray, makeRoom)
+		writeBuffer.bind(this)(typedArray, makeRoom)
 	}
 },
 	typedArrayEncoder(68, 1),
@@ -1152,6 +1180,14 @@ function typedArrayEncoder(tag, size) {
 }
 function writeBuffer(buffer, makeRoom) {
 	let length = buffer.byteLength
+	if(buffer._cbor_indef && this && this.preserveIndefiniteLength){
+		target[position++]= 0x5f
+		buffer._cbor_indef.forEach(buf=>{
+			writeBuffer(buf,makeRoom)
+		})
+		target[position++] = 0xff
+		return;
+	}
 	if (length < 0x18) {
 		target[position++] = 0x40 + length
 	} else if (length < 0x100) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -25,6 +25,8 @@ function tryRequire(module) {
 var assert = chai.assert
 
 var Encoder = CBOR.Encoder
+var Decoder = CBOR.Encoder
+
 var EncoderStream = CBOR.EncoderStream
 var DecoderStream = CBOR.DecoderStream
 var decode = CBOR.decode
@@ -46,6 +48,10 @@ try {
 } catch (error) {}
 
 var ITERATIONS = 4000
+
+if(process.env.LOG_LEVEL !=='DEBUG' ){
+	console.debug=()=>{}
+}
 
 suite('CBOR basic tests', function(){
 	test('encode/decode with keyMaps (basic)', function() {
@@ -745,6 +751,30 @@ suite('CBOR basic tests', function(){
 		var serialized = encode(data)
 		var deserialized = decode(serialized)
 		assert.deepEqual(deserialized, data)
+	})
+	test ('re-encode indefinite length',()=>{
+		const decoder=new Decoder({preserveIndefiniteLength: true})
+		const encoder=new Encoder({preserveIndefiniteLength: true})
+
+
+		const data=Buffer.from('9F81007F6563626F72786563626F7278FF5F43ABCDEFFF7F6563626F7278FFBF6563626F7278F5FFFF','hex')
+		console.debug("re-encode indefinite length:initial   ",data.toString('hex'))
+
+		const decoded =  decoder.decode(data)
+		console.debug("re-encode indefinite length:decoded   ",decoded)
+
+		const reEncoded= encoder.encode(decoded)
+		console.debug("re-encode indefinite length:re-encoded",reEncoded.toString('hex'))
+
+		const defaultEncoded = CBOR.encode(decoded)
+		console.debug("re-encode not preserved:   encoded    ",defaultEncoded.toString('hex'))
+		assert.equal(defaultEncoded.toString('hex'),'8581006a63626f727863626f727843abcdef6563626f7278d90103a16563626f7278f5')
+
+
+		const reDecoded= decoder.decode(reEncoded)
+		console.debug("re-encode indefinite length:re-decoded",reDecoded)
+
+		assert.equal(data.toString('hex'), encoder.encode(reDecoded).toString('hex'))
 	})
 	test('decodeMultiple', () => {
 		let values = CBOR.decodeMultiple(new Uint8Array([1, 2, 3, 4]))


### PR DESCRIPTION
#### Why
Its important for my use-case that re-encoding some portion of decoded data creates the same binary.

#### What
When decoding indefinite length array, text, binary or map, 
- return a  proxy of the type
- retain the original segments so that it can be re-encoded to same data.
- when encoding, if a flag is set, use the indefinite length encoding.
