### PR TITLE
add sortMaps:bool option

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -509,7 +509,7 @@ export class Encoder extends Decoder {
 								encode(entryValue)
 							} 
 						} else {
-							const keys = Array.from(value.keys()).sort()
+							const keys = Array.from(value.keys()).sort(lexSortFn)
 							for (let key of keys) {
 								encode(key) 
 								encode(value.get(key))

--- a/encode.js
+++ b/encode.js
@@ -614,7 +614,7 @@ export class Encoder extends Decoder {
 		const writeObject = this.useRecords === false ? this.variableMapSize ? (object) => {
 			// this method is slightly slower, but generates "preferred serialization" (optimally small for smaller objects)
 			let keys = Object.keys(object)
-			if (this.sortMaps) keys.sort(lexSortFn)
+			if (sortMaps) keys.sort(lexSortFn)
 			let length = keys.length
 			if (length < 0x18) {
 				target[position++] = 0xa0 | length
@@ -655,7 +655,7 @@ export class Encoder extends Decoder {
 				}
 			} else {
 				const keys = Object.keys(object)
-				if (this.sortMaps) keys.sort(lexSortFn)
+				if (sortMaps) keys.sort(lexSortFn)
 				for (let key of keys) if (typeof object.hasOwnProperty !== 'function' || object.hasOwnProperty(key)) {
 						encode(key)
 						encode(object[key])
@@ -685,7 +685,7 @@ export class Encoder extends Decoder {
 				}				
 			} else {
 				const keys = Object.keys(object)
-				if (this.sortMaps) keys.sort(lexSortFn)
+				if (sortMaps) keys.sort(lexSortFn)
 				for (let key of keys) if (typeof object.hasOwnProperty !== 'function' || object.hasOwnProperty(key)) {
 					nextTransition = transition[key]
 					if (!nextTransition) {
@@ -802,7 +802,7 @@ export class Encoder extends Decoder {
 				else
 					writeEntityLength(Object.keys(object).length, 0xa0);
 				let keys = Object.keys(object)
-				if (this.sortMaps) keys.sort(lexSortFn)
+				if (sortMaps) keys.sort(lexSortFn)
 				for (let key of keys) {
 					let value = object[key];
 					if (!useRecords) encode(key);

--- a/encode.js
+++ b/encode.js
@@ -39,6 +39,7 @@ export class Encoder extends Decoder {
 			} : false
 
 		let encoder = this
+		const sortMaps = options.sortMaps || false
 		let hasSharedStructures = options.structures || options.saveStructures
 		let maxSharedStructures = options.maxSharedStructures
 		if (maxSharedStructures == null)
@@ -507,10 +508,12 @@ export class Encoder extends Decoder {
 								encode(encoder.encodeKey(key))
 								encode(entryValue)
 							} 
-						} else { 
-							for (let [ key, entryValue ] of value) {
+						} else {
+							const keys = Object.keys(value)
+							if (this.sortMaps) keys.sort(lexSortFn)
+							for (let key of keys) {
 								encode(key) 
-								encode(entryValue)
+								encode(value[key])
 							} 	
 						}
 					} else {
@@ -611,7 +614,7 @@ export class Encoder extends Decoder {
 		const writeObject = this.useRecords === false ? this.variableMapSize ? (object) => {
 			// this method is slightly slower, but generates "preferred serialization" (optimally small for smaller objects)
 			let keys = Object.keys(object)
-			let vals = Object.values(object)
+			if (this.sortMaps) keys.sort(lexSortFn)
 			let length = keys.length
 			if (length < 0x18) {
 				target[position++] = 0xa0 | length
@@ -627,16 +630,15 @@ export class Encoder extends Decoder {
 				targetView.setUint32(position, length)
 				position += 4
 			}
-			let key
 			if (encoder.keyMap) { 
 				for (let i = 0; i < length; i++) {
 					encode(encoder.encodeKey(keys[i]))
-					encode(vals[i])
+					encode(object[keys[i]])
 				}
 			} else {
 				for (let i = 0; i < length; i++) {
 					encode(keys[i])
-					encode(vals[i])
+					encode(object[keys[i]])
 				}
 			}
 		} :
@@ -651,8 +653,10 @@ export class Encoder extends Decoder {
 					encode(object[key])
 					size++
 				}
-			} else { 
-				for (let key in object) if (typeof object.hasOwnProperty !== 'function' || object.hasOwnProperty(key)) {
+			} else {
+				const keys = Object.keys(object)
+				if (this.sortMaps) keys.sort(lexSortFn)
+				for (let key of keys) if (typeof object.hasOwnProperty !== 'function' || object.hasOwnProperty(key)) {
 						encode(key)
 						encode(object[key])
 					size++
@@ -680,7 +684,9 @@ export class Encoder extends Decoder {
 					transition = nextTransition
 				}				
 			} else {
-				for (let key in object) if (typeof object.hasOwnProperty !== 'function' || object.hasOwnProperty(key)) {
+				const keys = Object.keys(object)
+				if (this.sortMaps) keys.sort(lexSortFn)
+				for (let key of keys) if (typeof object.hasOwnProperty !== 'function' || object.hasOwnProperty(key)) {
 					nextTransition = transition[key]
 					if (!nextTransition) {
 						if (transition[RECORD_SYMBOL] & 0x100000) {// this indicates it is a brancheable/extendable terminal node, so we will use this record id and extend it
@@ -795,7 +801,9 @@ export class Encoder extends Decoder {
 					writeObject(object, true); // write the record identifier
 				else
 					writeEntityLength(Object.keys(object).length, 0xa0);
-				for (let key in object) {
+				let keys = Object.keys(object)
+				if (this.sortMaps) keys.sort(lexSortFn)
+				for (let key of keys) {
 					let value = object[key];
 					if (!useRecords) encode(key);
 					if (value && typeof value === 'object') {
@@ -1227,5 +1235,8 @@ export const { NEVER, ALWAYS, DECIMAL_ROUND, DECIMAL_FIT } = FLOAT32_OPTIONS
 export const REUSE_BUFFER_MODE = 512
 export const RESET_BUFFER_MODE = 1024
 export const THROW_ON_ITERABLE = 2048
-
-
+const lexSortFn = (a, b) => {
+	if (a.length < b.length) return -1
+	if (a.length > b.length) return 1
+	return a < b ? -1 : 1
+}

--- a/encode.js
+++ b/encode.js
@@ -509,12 +509,11 @@ export class Encoder extends Decoder {
 								encode(entryValue)
 							} 
 						} else {
-							const keys = Object.keys(value)
-							if (this.sortMaps) keys.sort(lexSortFn)
+							const keys = Array.from(value.keys()).sort()
 							for (let key of keys) {
 								encode(key) 
-								encode(value[key])
-							} 	
+								encode(value.get(key))
+							}
 						}
 					} else {
 						for (let i = 0, l = extensions.length; i < l; i++) {

--- a/tests/test-sorted-maps.js
+++ b/tests/test-sorted-maps.js
@@ -1,0 +1,33 @@
+import * as CBOR from '../node-index.js'
+import chai from 'chai'
+var assert = chai.assert
+var Encoder = CBOR.Encoder
+
+const data = {
+	z: 3,
+	y: 2,
+	x: 1,
+	"1111": 4,
+}
+
+suite('CBOR canonicalization', function(){
+	test('encode with sorted maps', function() {
+		let cbor = new Encoder({
+			useRecords: false,
+			mapsAsObjects: false,
+			variableMapSize: true,
+			sortMaps: true,
+		})
+		let serialized = bytesToHex(cbor.encode(data))
+		console.log("encoded:", serialized)
+
+		const want = "a4617801617902617a03643131313104"
+		assert.equal(serialized, want)
+	})
+})
+
+function bytesToHex(bytes) {
+	return Array.from(bytes)
+	  .map(b => b.toString(16).padStart(2, '0'))
+	  .join('')
+}

--- a/tests/test-sorted-maps.js
+++ b/tests/test-sorted-maps.js
@@ -3,25 +3,42 @@ import chai from 'chai'
 var assert = chai.assert
 var Encoder = CBOR.Encoder
 
-const data = {
-	z: 3,
-	y: 2,
-	x: 1,
-	"1111": 4,
+
+const options = {
+	useRecords: false,
+	mapsAsObjects: false,
+	variableMapSize: true,
+	sortMaps: true,
 }
 
-suite('CBOR canonicalization', function(){
-	test('encode with sorted maps', function() {
-		let cbor = new Encoder({
-			useRecords: false,
-			mapsAsObjects: false,
-			variableMapSize: true,
-			sortMaps: true,
-		})
-		let serialized = bytesToHex(cbor.encode(data))
-		console.log("encoded:", serialized)
+const want = "a5617801617902617a036361616104643131313105"
 
-		const want = "a4617801617902617a03643131313104"
+suite('CBOR canonicalization', function(){
+	test('encode with sorted objects', function() {
+		let cbor = new Encoder(options)
+		const obj = {
+			z: 3,
+			y: 2,
+			x: 1,
+			"1111": 5,
+			"aaa": 4,
+		}
+		let serialized = bytesToHex(cbor.encode(obj))
+		assert.equal(serialized, want)
+	})
+
+	test("encode map with sorted keys", function() {
+		options.useTag259ForMaps = false
+		let cbor = new Encoder(options)
+
+		const map = new Map([
+			["z", 3],
+			["y", 2],
+			["x", 1],
+			["1111", 5],
+			["aaa", 4],
+		])
+		let serialized = bytesToHex(cbor.encode(map))
 		assert.equal(serialized, want)
 	})
 })


### PR DESCRIPTION
This starts the work on adding `sortMap:bool` to make it easy to create canonical map representations.

I had trouble resolving these two comments:
* https://github.com/kriszyp/cbor-x/issues/4#issuecomment-1591358930
* https://github.com/kriszyp/cbor-x/issues/61#issuecomment-1336570860

I don't really see the point in moving this to a different library. Since the comment on 4 was newer I just went ahead and did it to see how hard it would be.

My rationale for doing it this way would be:

* re-creating a map/object with sorted keys is not very memory efficient either
* it bubbles up the problem to parts of the stack that might not (want to) care about it
* this code already iterates over keys list anyway, so we just need to sort those

This surely needs more tests before it can be merged/released but I wanted to get a temp check before I spent too much time on this.
